### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/jarrettgilliam/snake/security/code-scanning/1](https://github.com/jarrettgilliam/snake/security/code-scanning/1)

In general, fix this by explicitly specifying a `permissions` block for the affected job (or at the workflow root) to restrict the `GITHUB_TOKEN` to the minimal scopes needed. For a build job that only checks out code and uploads an artifact, read-only access to repository contents is sufficient.

Concretely, edit `.github/workflows/deploy-pages.yml` and add a `permissions` block under the `build` job, alongside `runs-on`. The minimal safe setting is:

```yaml
permissions:
  contents: read
```

This limits the `GITHUB_TOKEN` for the `build` job to read-only repository contents, which is enough for `actions/checkout@v4` and does not interfere with `oven-sh/setup-bun@v2` or `actions/upload-pages-artifact@v3` (these do not need repo write access). No other files, imports, or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
